### PR TITLE
Corrected Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,8 @@ test: test_biniou$(EXE)
 	./$<
 
 ifndef PREFIX
-  PREFIX != dirname $$(dirname $$(which ocamlfind))
-  export PREFIX
+	PREFIX != dirname $$(dirname $$(which ocamlfind))
+	export PREFIX
 endif
 
 ifndef BINDIR


### PR DESCRIPTION
This correction removes make error:

Makefile:48: *** missing separator.  Stop.

GNU Make 3.82