### PR TITLE
Enable biniou to be safe-string compatible

### DIFF
--- a/src/bi_inbuf.ml
+++ b/src/bi_inbuf.ml
@@ -1,5 +1,5 @@
 type t = {
-  mutable i_s : string;
+  mutable i_s : bytes;
   mutable i_pos : int;
   mutable i_len : int;
   mutable i_offs : int;
@@ -35,14 +35,14 @@ let read ib n =
 let read_char ib =
   let pos = ib.i_pos in
   if ib.i_len - pos > 0 then (
-    let c = String.unsafe_get ib.i_s pos in
+    let c = Bytes.unsafe_get ib.i_s pos in
     ib.i_pos <- pos + 1;
     c
   )
   else
     if try_preread ib 1 > 0 then
       let pos = ib.i_pos in
-      let c = String.unsafe_get ib.i_s pos in
+      let c = Bytes.unsafe_get ib.i_s pos in
       ib.i_pos <- pos + 1;
       c
     else
@@ -51,16 +51,16 @@ let read_char ib =
 let peek ib =
   let pos = ib.i_pos in
   if ib.i_len - pos > 0 then (
-    String.unsafe_get ib.i_s pos
+    Bytes.unsafe_get ib.i_s pos
   )
   else
     if try_preread ib 1 > 0 then
-      String.unsafe_get ib.i_s ib.i_pos
+      Bytes.unsafe_get ib.i_s ib.i_pos
     else
       raise End_of_input
 
 let from_string ?(pos = 0) ?(shrlen = 16) s = {
-  i_s = s;
+  i_s = Bytes.of_string s;
   i_pos = pos;
   i_len = String.length s;
   i_offs = -pos;
@@ -87,7 +87,7 @@ let refill_from_channel ic ib n =
     let rem_len = ib.i_len - ib.i_pos in
     if rem_len < n then
       let s = ib.i_s in
-      String.blit s ib.i_pos s 0 rem_len;
+      Bytes.blit s ib.i_pos s 0 rem_len;
       let to_read = n - rem_len in
       let really_read = not_really_input ic s rem_len to_read 0 in
       ib.i_offs <- ib.i_offs + ib.i_pos;
@@ -96,7 +96,7 @@ let refill_from_channel ic ib n =
   )
 
 let from_channel ?(len = 4096) ?(shrlen = 16) ic = {
-  i_s = String.create len;
+  i_s = Bytes.create len;
   i_pos = 0;
   i_len = 0;
   i_offs = 0;

--- a/src/bi_inbuf.mli
+++ b/src/bi_inbuf.mli
@@ -1,7 +1,7 @@
 (** Input buffer *)
 
 type t = {
-  mutable i_s : string;
+  mutable i_s : bytes;
     (** This is the buffer string.
        It can be accessed for reading but should normally only
        be written to or replaced only by the [i_refill] function.

--- a/src/bi_io.ml
+++ b/src/bi_io.ml
@@ -89,13 +89,13 @@ let write_hashtag ob h has_arg =
   let h = mask_31bit h in
   let pos = Bi_outbuf.alloc ob 4 in
   let s = ob.o_s in
-  String.unsafe_set s (pos+3) (Char.chr (h land 0xff));
+  Bytes.unsafe_set s (pos+3) (Char.chr (h land 0xff));
   let h = h lsr 8 in
-  String.unsafe_set s (pos+2) (Char.chr (h land 0xff));
+  Bytes.unsafe_set s (pos+2) (Char.chr (h land 0xff));
   let h = h lsr 8 in
-  String.unsafe_set s (pos+1) (Char.chr (h land 0xff));
+  Bytes.unsafe_set s (pos+1) (Char.chr (h land 0xff));
   let h = h lsr 8 in
-  String.unsafe_set s pos (
+  Bytes.unsafe_set s pos (
     Char.chr (
       if has_arg then h lor 0x80
       else h
@@ -109,7 +109,7 @@ let string_of_hashtag h has_arg =
 
 let read_hashtag ib cont =
   let i = Bi_inbuf.read ib 4 in
-  let s = ib.i_s in
+  let s = Bytes.to_string ib.i_s in
   let x0 = Char.code s.[i] in
   let has_arg = x0 >= 0x80 in
   let x1 = (x0 land 0x7f) lsl 24 in
@@ -123,7 +123,7 @@ let read_hashtag ib cont =
 
 let read_field_hashtag ib =
   let i = Bi_inbuf.read ib 4 in
-  let s = ib.i_s in
+  let s = Bytes.to_string ib.i_s in
   let x0 = Char.code (String.unsafe_get s i) in
   if x0 < 0x80 then
     Bi_util.error "Corrupted data (invalid field hashtag)";
@@ -147,7 +147,8 @@ let write_numtag ob i has_arg =
 
 let read_numtag ib cont =
   let i = Bi_inbuf.read ib 1 in
-  let x = Char.code ib.i_s.[i] in
+  let s = Bytes.to_string ib.i_s in
+  let x = Char.code s.[i] in
   let has_arg = x >= 0x80 in
   cont ib (x land 0x7f) has_arg
 
@@ -214,16 +215,16 @@ let float_endianness = lazy (
 
 let read_untagged_float64 ib =
   let i = Bi_inbuf.read ib 8 in
-  let s = ib.i_s in
+  let s = Bytes.to_string ib.i_s in
   let x = Obj.new_block Obj.double_tag 8 in
   (match Lazy.force float_endianness with
        `Little ->
 	 for j = 0 to 7 do
-	   String.unsafe_set (Obj.obj x) (7-j) (String.unsafe_get s (i+j))
+	   Bytes.unsafe_set (Obj.obj x) (7-j) (String.unsafe_get s (i+j))
 	 done
      | `Big ->
 	 for j = 0 to 7 do
-	   String.unsafe_set (Obj.obj x) j (String.unsafe_get s (i+j))
+	   Bytes.unsafe_set (Obj.obj x) j (String.unsafe_get s (i+j))
 	 done
   );
   (Obj.obj x : float)
@@ -234,11 +235,11 @@ let write_untagged_float64 ob x =
   (match Lazy.force float_endianness with
        `Little ->
 	 for j = 0 to 7 do
-	   String.unsafe_set s (i+j) (String.unsafe_get (Obj.magic x) (7-j))
+	   Bytes.unsafe_set s (i+j) (String.unsafe_get (Obj.magic x) (7-j))
 	 done
      | `Big ->
 	 for j = 0 to 7 do
-	   String.unsafe_set s (i+j) (String.unsafe_get (Obj.magic x) j)
+	   Bytes.unsafe_set s (i+j) (String.unsafe_get (Obj.magic x) j)
 	 done
   )
 
@@ -525,13 +526,13 @@ let read_untagged_int8 ib =
 
 let read_untagged_int16 ib =
   let i = Bi_inbuf.read ib 2 in
-  let s = ib.i_s in
+  let s = Bytes.to_string ib.i_s in
   ((Char.code s.[i]) lsl 8) lor (Char.code s.[i+1])
 
 
 let read_untagged_int32 ib =
   let i = Bi_inbuf.read ib 4 in
-  let s = ib.i_s in
+  let s = Bytes.to_string ib.i_s in
   let x1 =
     Int32.of_int (((Char.code s.[i  ]) lsl 8) lor (Char.code s.[i+1])) in
   let x2 =
@@ -565,7 +566,7 @@ let read_untagged_int64 ib =
 
 let read_untagged_string ib =
   let len = Bi_vint.read_uvint ib in
-  let str = String.create len in
+  let str = Bytes.create len in
   let pos = ref 0 in
   let rem = ref len in
   while !rem > 0 do
@@ -573,13 +574,13 @@ let read_untagged_string ib =
     if bytes_read = 0 then
       Bi_util.error "Corrupted data (string)"
     else (
-      String.blit ib.i_s ib.i_pos str !pos bytes_read;
+      Bytes.blit ib.i_s ib.i_pos str !pos bytes_read;
       ib.i_pos <- ib.i_pos + bytes_read;
       pos := !pos + bytes_read;
       rem := !rem - bytes_read
     )
   done;
-  str
+  Bytes.to_string str
 
 let read_untagged_uvint = Bi_vint.read_uvint
 let read_untagged_svint = Bi_vint.read_svint

--- a/src/bi_outbuf.ml
+++ b/src/bi_outbuf.ml
@@ -1,5 +1,5 @@
 type t = {
-  mutable o_s : string;
+  mutable o_s : bytes;
   mutable o_max_len : int;
   mutable o_len : int;
   mutable o_offs : int;
@@ -21,23 +21,24 @@ let really_extend b n =
       else
 	Sys.max_string_length
   in
-  let s = String.create slen in
-  String.blit b.o_s 0 s 0 b.o_len;
+  let s = Bytes.create slen in
+  Bytes.blit b.o_s 0 s 0 b.o_len;
   b.o_s <- s;
   b.o_max_len <- slen
 
 let flush_to_output abstract_output b n =
-  abstract_output b.o_s 0 b.o_len;
+  abstract_output (Bytes.to_string b.o_s) 0 b.o_len;
   b.o_offs <- b.o_offs + b.o_len;
   b.o_len <- 0;
   if n > b.o_max_len then
     really_extend b n
 
-let flush_to_channel oc = flush_to_output (output oc)
+let flush_to_channel oc =
+  flush_to_output (fun s start len -> output_string oc (String.sub s start len))
 
 
 let create ?(make_room = really_extend) ?(shrlen = 16) n = {
-  o_s = String.create n;
+  o_s = Bytes.create n;
   o_max_len = n;
   o_len = 0;
   o_offs = 0;
@@ -83,26 +84,26 @@ let add_string b s =
 
 let add_char b c =
   let pos = alloc b 1 in
-  b.o_s.[pos] <- c
+  Bytes.set b.o_s pos c
 
 let unsafe_add_char b c =
   let len = b.o_len in
-  b.o_s.[len] <- c;
+  Bytes.set b.o_s len c;
   b.o_len <- len + 1
 
 let add_char2 b c1 c2 =
   let pos = alloc b 2 in
   let s = b.o_s in
-  String.unsafe_set s pos c1;
-  String.unsafe_set s (pos+1) c2
+  Bytes.unsafe_set s pos c1;
+  Bytes.unsafe_set s (pos+1) c2
 
 let add_char4 b c1 c2 c3 c4 =
   let pos = alloc b 4 in
   let s = b.o_s in
-  String.unsafe_set s pos c1;
-  String.unsafe_set s (pos+1) c2;
-  String.unsafe_set s (pos+2) c3;
-  String.unsafe_set s (pos+3) c4
+  Bytes.unsafe_set s pos c1;
+  Bytes.unsafe_set s (pos+1) c2;
+  Bytes.unsafe_set s (pos+2) c3;
+  Bytes.unsafe_set s (pos+3) c4
 
 
 
@@ -112,10 +113,10 @@ let clear b =
   Bi_share.Wr.clear b.o_shared
 
 let reset b =
-  if String.length b.o_s <> b.o_init_len then
-    b.o_s <- String.create b.o_init_len;
+  if Bytes.length b.o_s <> b.o_init_len then
+    b.o_s <- Bytes.create b.o_init_len;
   b.o_offs <- 0;
   b.o_len <- 0;
   b.o_shared <- Bi_share.Wr.create b.o_shared_init_len
 
-let contents b = String.sub b.o_s 0 b.o_len
+let contents b = Bytes.to_string (Bytes.sub b.o_s 0 b.o_len)

--- a/src/bi_outbuf.mli
+++ b/src/bi_outbuf.mli
@@ -1,7 +1,7 @@
 (** Output buffer *)
 
 type t = {
-  mutable o_s : string;
+  mutable o_s : bytes;
     (** Buffer string *)
 
   mutable o_max_len : int;

--- a/src/bi_stream.ml
+++ b/src/bi_stream.ml
@@ -53,9 +53,9 @@ let rec read_chunk of_string ic =
           error
             (sprintf
                "Corrupted stream: excessive chunk length (%i bytes)" len);
-        let s = String.create len in
+        let s = Bytes.create len in
         really_input ic s 0 len;
-        Some (of_string s)
+        Some (of_string (Bytes.to_string s))
 
     | '\000' -> None
 

--- a/src/bi_util.ml
+++ b/src/bi_util.ml
@@ -8,18 +8,18 @@ let error s = raise (Error s)
 *)
 
 let string8_of_int x =
-  let s = String.create 8 in
+  let s = Bytes.create 8 in
   for i = 0 to 7 do
-    s.[7-i] <- Char.chr (0xff land (x lsr (8 * i)))
+    Bytes.set s (7-i) (Char.chr (0xff land (x lsr (8 * i))))
   done;
-  s
+  Bytes.to_string s
 
 let string4_of_int x =
-  let s = String.create 4 in
+  let s = Bytes.create 4 in
   for i = 0 to 3 do
-    s.[3-i] <- Char.chr (0xff land (x lsr (8 * i)))
+    Bytes.set s (3-i) (Char.chr (0xff land (x lsr (8 * i))))
   done;
-  s
+  Bytes.to_string s
 
 let print_bits ?(pos = 0) ?len s =
   let slen = String.length s in
@@ -33,16 +33,16 @@ let print_bits ?(pos = 0) ?len s =
           else len
   in
 
-  let r = String.create (len * 9) in
+  let r = Bytes.create (len * 9) in
   for i = 0 to len - 1 do
     let k = i * 9 in
     let x = Char.code s.[pos+i] in
     for j = 0 to 7 do
-      r.[k+j] <- if (x lsr (7 - j)) land 1 = 0 then '0' else '1'
+      Bytes.set r (k+j) (if (x lsr (7 - j)) land 1 = 0 then '0' else '1')
     done;
-    r.[k+8] <- if (i + 1) mod 8 = 0 then '\n' else ' '
+    Bytes.set r (k+8) (if (i + 1) mod 8 = 0 then '\n' else ' ')
   done;
-  r
+  Bytes.to_string r
 
 (* int size in bits *)
 let int_size =

--- a/src/bi_vint.ml
+++ b/src/bi_vint.ml
@@ -75,7 +75,7 @@ let svint_of_int ?buf i =
 
 let read_uvint ib =
   let avail = Bi_inbuf.try_preread ib max_vint_bytes in
-  let s = ib.i_s in
+  let s = Bytes.to_string ib.i_s in
   let pos = ib.i_pos in
   let x = ref 0 in
   (try

--- a/src/jbuild
+++ b/src/jbuild
@@ -5,4 +5,4 @@
   (public_name biniou)
   (synopsis "Extensible binary serialization format")
   (wrapped false)
-  (libraries (easy-format))))
+  (libraries (easy-format bytes))))


### PR DESCRIPTION
I'm not sure about changing the type of ```Bi_inbuf.t``` and ```Bi_outbuf.t``` but it seems legit in relation with the rest of the code.