### PR TITLE
Improvements linked to #22

### DIFF
--- a/src/bi_inbuf.ml
+++ b/src/bi_inbuf.ml
@@ -59,15 +59,17 @@ let peek ib =
     else
       raise End_of_input
 
-let from_string ?(pos = 0) ?(shrlen = 16) s = {
-  i_s = Bytes.of_string s;
+let from_bytes ?(pos = 0) ?(shrlen = 16) s = {
+  i_s = s;
   i_pos = pos;
-  i_len = String.length s;
+  i_len = Bytes.length s;
   i_offs = -pos;
-  i_max_len = String.length s;
+  i_max_len = Bytes.length s;
   i_refill = (fun ib n -> ());
   i_shared = Bi_share.Rd.create shrlen;
 }
+
+let from_string ?pos ?shrlen s = from_bytes ?pos ?shrlen (Bytes.of_string s)
 
 (*
   Like Pervasives.really_input but returns the number of bytes

--- a/src/bi_inbuf.mli
+++ b/src/bi_inbuf.mli
@@ -99,6 +99,14 @@ val from_string : ?pos:int -> ?shrlen:int -> string -> t
      @param shrlen  initial length of the table used to store shared values.
   *)
 
+val from_bytes : ?pos:int -> ?shrlen:int -> bytes -> t
+  (**
+     Create an input buffer from bytes.
+     @param pos     position to start from. Default: 0.
+     @param shrlen  initial length of the table used to store shared values.
+     @since 1.2.0
+  *)
+
 val from_channel : ?len:int -> ?shrlen:int -> in_channel -> t
   (**
      Create an input buffer from an in_channel.

--- a/src/bi_outbuf.ml
+++ b/src/bi_outbuf.ml
@@ -72,13 +72,19 @@ let alloc b n =
   b.o_len <- pos + n;
   pos
 
-let add_substring b s pos len =
+let add_sub blit b s pos len =
   extend b len;
-  String.blit s pos b.o_s b.o_len len;
+  blit s pos b.o_s b.o_len len;
   b.o_len <- b.o_len + len
+
+let add_substring = add_sub String.blit
+let add_subbytes = add_sub Bytes.blit
 
 let add_string b s =
   add_substring b s 0 (String.length s)
+
+let add_bytes b s =
+  add_subbytes b s 0 (Bytes.length s)
 
 
 let add_char b c =

--- a/src/bi_outbuf.ml
+++ b/src/bi_outbuf.ml
@@ -33,8 +33,7 @@ let flush_to_output abstract_output b n =
   if n > b.o_max_len then
     really_extend b n
 
-let flush_to_channel oc =
-  flush_to_output (fun s start len -> output_string oc (String.sub s start len))
+let flush_to_channel oc = flush_to_output (output_substring oc)
 
 
 let create ?(make_room = really_extend) ?(shrlen = 16) n = {

--- a/src/bi_outbuf.ml
+++ b/src/bi_outbuf.ml
@@ -124,4 +124,4 @@ let reset b =
   b.o_len <- 0;
   b.o_shared <- Bi_share.Wr.create b.o_shared_init_len
 
-let contents b = Bytes.to_string (Bytes.sub b.o_s 0 b.o_len)
+let contents b = Bytes.sub_string b.o_s 0 b.o_len

--- a/src/bi_outbuf.mli
+++ b/src/bi_outbuf.mli
@@ -90,6 +90,17 @@ val alloc : t -> int -> int
     by accessing [buf.s] directly.
   *)
 
+val add_bytes : t -> bytes -> unit
+  (** Add bytes to the buffer.
+
+      @since 1.2.0 *)
+
+val add_subbytes : t -> bytes -> int -> int -> unit
+  (** [add_subbytes dst src srcpos len] copies [len] bytes from
+     bytes [src] to buffer [dst] starting from position [srcpos].
+
+     @since 1.2.0 *)
+
 val add_string : t -> string -> unit
   (** Add a string to the buffer. *)
 

--- a/src/bi_vint.ml
+++ b/src/bi_vint.ml
@@ -75,12 +75,12 @@ let svint_of_int ?buf i =
 
 let read_uvint ib =
   let avail = Bi_inbuf.try_preread ib max_vint_bytes in
-  let s = Bytes.to_string ib.i_s in
+  let s = ib.i_s in
   let pos = ib.i_pos in
   let x = ref 0 in
   (try
      for i = 0 to avail - 1 do
-       let b = Char.code s.[pos+i] in
+       let b = Char.code (Bytes.get s (pos+i)) in
        x := ((b land 0x7f) lsl (7*i)) lor !x;
        if b < 0x80 then (
 	 ib.i_pos <- pos + i + 1;


### PR DESCRIPTION
This PR adds a couple of functions that takes bytes instead of string, changes the type of create_output_write and do some optimizations.
I believe it it better (e.g. faster and probably better for compatibility purpose) to use ```bytes -> int -> int -> int``` as the output function even if bytes shouldn't be modified because it avoids using the ""costly"" ```Bytes.to_string```.

For the new functions, I added a comment ```@since 1.2.0```, I don't know what is your version scheme but I would assume to change the minor version on API changes. If you prefer an other version number, let me know.